### PR TITLE
FIX numpy.int overflow in make_classification

### DIFF
--- a/sklearn/datasets/samples_generator.py
+++ b/sklearn/datasets/samples_generator.py
@@ -161,7 +161,7 @@ def make_classification(n_samples=100, n_features=20, n_informative=2,
         raise ValueError("Number of informative, redundant and repeated "
                          "features must sum to less than the number of total"
                          " features")
-    if 2 ** n_informative < n_classes * n_clusters_per_class:
+    if 2 ** int(n_informative) < n_classes * n_clusters_per_class:
         raise ValueError("n_classes * n_clusters_per_class must"
                          " be smaller or equal 2 ** n_informative")
     if weights and len(weights) not in [n_classes, n_classes - 1]:


### PR DESCRIPTION
The sample generator `make_classification()` raises misleading errors on certain valid inputs.

#### What does this implement/fix? Explain your changes.
The sample generator `make_classification()` checks its parameters, 
e.g. `2 ** n_informative < n_classes * n_clusters_per_class`.

If `n_informative` is given as numpy.int with a value of 64 or larger,
`2 ** n_informative` evaluates to 0, and the check fails with a misleading error message.

Casting to Python int() avoids this issue.

#### Reproduce the error
```python
>>> import numpy as np
>>> from sklearn.datasets import make_classification 
>>> N_INFORMATIVE = np.arange(31, 65)
>>> for n_informative in N_INFORMATIVE:
>>>      print(f'n_informative = {n_informative}, 2 ** n_informative = {2 ** n_informative}')
>>>      make_classification(n_features=100, 
>>>          n_informative=n_informative, n_classes=2, n_clusters_per_class=1)
```


#### Any other comments?
`2. ** n_informative` would also do the trick.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
